### PR TITLE
Make react-transition-group a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "material-ui": "^0.17.4",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "react-tap-event-plugin": "^2.0.1",
-    "react-transition-group": "^1.1.1"
+    "react-tap-event-plugin": "^2.0.1"
   },
   "peerDependencies": {
     "material-ui": "^0.17.4",
@@ -47,6 +46,7 @@
     "react-tap-event-plugin": "^2.0.1"
   },
   "dependencies": {
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "react-transition-group": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,16 +37,17 @@
     "material-ui": "^0.17.4",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "react-tap-event-plugin": "^2.0.1"
+    "react-tap-event-plugin": "^2.0.1",
+    "react-transition-group": "^1.1.1"
   },
   "peerDependencies": {
     "material-ui": "^0.17.4",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "react-tap-event-plugin": "^2.0.1"
+    "react-tap-event-plugin": "^2.0.1",
+    "react-transition-group": "^1.1.1"
   },
   "dependencies": {
-    "prop-types": "^15.5.8",
-    "react-transition-group": "^1.1.1"
+    "prop-types": "^15.5.8"
   }
 }


### PR DESCRIPTION
This is used in actual code, not just in development.