### PR TITLE
Close #8 In material-ui 0.19.0 onTouchTap has been removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import FullscreenDialog from 'material-ui-fullscreen-dialog'
   title={'Demo dialog'}
   actionButton={<FlatButton
     label='Done'
-    onTouchTap={() => this.setState({ open: false })}
+    onClick={() => this.setState({ open: false })}
   />}
 >
   // dialog content here

--- a/package-lock.json
+++ b/package-lock.json
@@ -4487,12 +4487,6 @@
       "integrity": "sha1-Qe4srHLU1P1wpjiW2pjhNzm4Rig=",
       "dev": true
     },
-    "react-tap-event-plugin": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz",
-      "integrity": "sha1-MWvrO8ZVbinshppyk+icgmqQdNI=",
-      "dev": true
-    },
     "react-transition-group": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-fullscreen-dialog",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "dependencies": {
     "@kadira/react-split-pane": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
-    "material-ui": "^0.17.4",
+    "material-ui": "^0.19.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-tap-event-plugin": "^2.0.1",
@@ -44,7 +44,7 @@
     "standard": "^10.0.2"
   },
   "peerDependencies": {
-    "material-ui": ">=0.17.0 <1.0.0",
+    "material-ui": ">=0.19.0 <1.0.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-tap-event-plugin": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "material-ui": "^0.19.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "react-tap-event-plugin": "^2.0.1",
     "react-transition-group": "^1.1.1",
     "standard": "^10.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-fullscreen-dialog",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A fullscreen dialog for Material-UI.",
   "main": "lib/FullscreenDialog.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "material-ui": ">=0.19.0 <1.0.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "react-tap-event-plugin": "^2.0.1",
     "react-transition-group": "^1.1.1"
   },
   "dependencies": {

--- a/src/FullscreenDialog.js
+++ b/src/FullscreenDialog.js
@@ -57,7 +57,7 @@ export default function FullscreenDialog (props, { muiTheme }) {
         titleStyle={titleStyle}
         style={{ ...styles.appBar, ...appBarStyle }}
         iconElementLeft={(
-          <IconButton onTouchTap={onRequestClose}>
+          <IconButton onClick={onRequestClose}>
             {closeIcon || <NavigationCloseIcon />}
           </IconButton>
         )}

--- a/stories/FullscreenDialogDemo.js
+++ b/stories/FullscreenDialogDemo.js
@@ -26,7 +26,7 @@ export default class extends React.Component {
           title='Some demo dialog'
           actionButton={<FlatButton
             label='Done'
-            onTouchTap={() => this.setState({ open: false })}
+            onClick={() => this.setState({ open: false })}
           />}
         >
           <TextField
@@ -38,7 +38,7 @@ export default class extends React.Component {
         </FullscreenDialog>
 
         <RaisedButton
-          onTouchTap={() => this.setState({ open: true })}
+          onClick={() => this.setState({ open: true })}
           label='Open dialog'
         />
       </div>


### PR DESCRIPTION
Issue: https://github.com/TeamWertarbyte/material-ui-fullscreen-dialog/issues/8