### PR TITLE
allow appBarZDepth to be set to 0

### DIFF
--- a/src/FullscreenDialog.js
+++ b/src/FullscreenDialog.js
@@ -75,7 +75,7 @@ export default function FullscreenDialog (props, { muiTheme }) {
 FullscreenDialog.propTypes = {
   actionButton: PropTypes.node,
   appBarStyle: PropTypes.object,
-  appBarZDepth: PropTypes.oneOf([1, 2, 3, 4, 5]),
+  appBarZDepth: PropTypes.oneOf([0, 1, 2, 3, 4, 5]),
   children: PropTypes.node,
   closeIcon: PropTypes.node,
   containerStyle: PropTypes.object,


### PR DESCRIPTION
Simple PR to allow appBarZDepth to be set to 0.

```javascript
...
appBarZDepth: PropTypes.oneOf([0, 1, 2, 3, 4, 5]),
...
```